### PR TITLE
fix ufw startup

### DIFF
--- a/elements/ufw/post-install.d/99-firewall
+++ b/elements/ufw/post-install.d/99-firewall
@@ -23,7 +23,7 @@ ufw default deny incoming || true
 # Instead, create a rc.local file, this will be executed by systemd rc-local.service on boot
 cat > /etc/rc.local <<- 'EOM'
 #!/bin/sh
-echo "ufw --force enable"
+ufw --force enable
 EOM
 # Ensure that /etc/rc.local is executable
 chmod +x /etc/rc.local

--- a/elements/ufw/post-install.d/99-firewall
+++ b/elements/ufw/post-install.d/99-firewall
@@ -17,7 +17,13 @@ ufw allow from 192.168.0.0/16
 ufw default deny incoming || true
 
 # Enable ufw
-ufw --force enable
-echo "ufw --force enable" >> /etc/rc.local
+# UFW can't run inside the chroot during image build, causing errors if we enable it here
+# ufw --force enable
+
+# Instead, create a rc.local file, this will be executed by systemd rc-local.service on boot
+cat > /etc/rc.local <<- 'EOM'
+#!/bin/sh
+echo "ufw --force enable"
+EOM
 # Ensure that /etc/rc.local is executable
 chmod +x /etc/rc.local


### PR DESCRIPTION
UFW can't run inside the chroot during image build, causing errors if we run "ufw --force enable"

Instead, we create it in a rc.local file, which is executed by the systemd rc-local.service on boot.
Since it's directly executed, we need to set an interpereter, otherwise we receive "exec format error"