### PR TITLE
remove ubuntu-cloud's grub override

### DIFF
--- a/elements/cc-ubuntu/pre-install.d/10-grub-compat
+++ b/elements/cc-ubuntu/pre-install.d/10-grub-compat
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# If this file is present, it overides changes to /etc/default/grub
+# https://bugs.launchpad.net/vmbuilder/+bug/1692471
+rm -f /etc/default/grub.d/50-cloudimg-settings.cfg || true


### PR DESCRIPTION
If this file is present, it overides changes to /etc/default/grub
See https://bugs.launchpad.net/vmbuilder/+bug/1692471