### PR TITLE
Remove flash-kernel dependency from ubuntu builds

### DIFF
--- a/elements/cc-common/package-installs.yaml
+++ b/elements/cc-common/package-installs.yaml
@@ -5,3 +5,7 @@ git:
 jq:
 linux-generic:
   when: DISTRO_NAME = ubuntu
+# ignore dependency
+# https://bugs.launchpad.net/ubuntu/+source/flash-kernel/+bug/1914712
+flash-kernel-:
+  arch: arm64


### PR DESCRIPTION
not removing flash-kernel is causing error when building arm64 images
`Processing triggers for flash-kernel (3.103ubuntu1~20.04.4) ... Unsupported platform.`

This is removed here - https://github.com/ChameleonCloud/CC-Images/commit/d982f69fbcb8cd242c951eb3c51158d847b4ae2d#diff-e0e93e0d4557f0a43b2ee2742bfaceae1876687d900158d0b50e5b6fadeb897bL7-L8 

