### PR TITLE
Adding nfs-common back to cc-common package installs

### DIFF
--- a/elements/cc-common/package-installs.yaml
+++ b/elements/cc-common/package-installs.yaml
@@ -3,5 +3,6 @@ build-essential:
   when: DISTRO_NAME = ubuntu
 git:
 jq:
+nfs-common:
 linux-generic:
   when: DISTRO_NAME = ubuntu


### PR DESCRIPTION
It is observed that nfs-common was removed for some reason from package installs This commit adds it back so manila share mounts work out of the box