### PR TITLE
build variant of ubuntu24.04 with hwe kernel

### DIFF
--- a/config/images.yaml
+++ b/config/images.yaml
@@ -67,10 +67,11 @@ CC-Ubuntu24.04:
 CC-Ubuntu24.04-hwe:
   arch:
     - amd64
+    - arm64
   provenance:
     distro: ubuntu
     release: noble
-    variant: base
+    variant: hwe
 
 CC-Ubuntu24.04-CUDA:
   depends:

--- a/config/images.yaml
+++ b/config/images.yaml
@@ -64,6 +64,14 @@ CC-Ubuntu24.04:
     release: noble
     variant: base
 
+CC-Ubuntu24.04-hwe:
+  arch:
+    - amd64
+  provenance:
+    distro: ubuntu
+    release: noble
+    variant: base
+
 CC-Ubuntu24.04-CUDA:
   depends:
     - CC-Ubuntu24.04

--- a/elements/cc-ubuntu24.04-hwe/element-deps
+++ b/elements/cc-ubuntu24.04-hwe/element-deps
@@ -1,0 +1,2 @@
+ubuntu
+cc-common

--- a/elements/cc-ubuntu24.04-hwe/environment.d/00-ubuntu-env
+++ b/elements/cc-ubuntu24.04-hwe/environment.d/00-ubuntu-env
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export DIB_RELEASE=noble
+export DIB_DISTRO_VERSION=24.04

--- a/elements/cc-ubuntu24.04-hwe/environment.d/01-cmdline-defaults
+++ b/elements/cc-ubuntu24.04-hwe/environment.d/01-cmdline-defaults
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# see https://github.com/openstack/diskimage-builder/tree/master/diskimage_builder/elements/bootloader
+
+
+# DIB_GRUB_TIMEOUT sets the grub menu timeout. It defaults to 5 seconds. Set this to 0 (no timeout) for fast boot times.
+export DIB_GRUB_TIMEOUT=0
+
+# Defaults, override if needed
+# export DIB_BOOTLOADER_USE_SERIAL_CONSOLE='True'
+# export DIB_BOOTLOADER_VIRTUAL_TERMINAL='tty0'
+
+# ttys0 is only default for amd64, leave unset so arm64 overrides it
+# export DIB_BOOTLOADER_SERIAL_CONSOLE='ttyS0,115200'
+
+# Defaults to True, but only matters for VMs with some flaky hypervisors.
+# Leaving it out unless we observe issues, can roll back
+export DIB_NO_TIMER_CHECK='False'
+
+# DIB_BOOTLOADER_DEFAULT_CMDLINE sets parameters that are appended to the 
+# GRUB_CMDLINE_LINUX_DEFAULT values in grub.cfg configuration. 
+# defaults to nofb nomodeset gfxpayload=text.
+# - nofb: removed, appears to be a no-op for ~20 years??
+# - nomodeset: removed, causes all sorts of issues with amdgpu, 
+#              and can cause excessive on some baremetal servers!
+# - gfxpayload=text: kept; probably ok, tells grub not to leave it at `auto`, 
+#                    and only impacts what video drivers load
+# - pci=realloc=off: added needed to handle badness on ubuntu with ubuntu and multi-gpus
+#                    centos distros have it turned off already
+export DIB_BOOTLOADER_DEFAULT_CMDLINE="gfxpayload=text pci=realloc=off"

--- a/elements/cc-ubuntu24.04-hwe/package-installs.yaml
+++ b/elements/cc-ubuntu24.04-hwe/package-installs.yaml
@@ -1,0 +1,9 @@
+linux-image-generic:
+   arch: amd64
+   when:
+    - DIB_RELEASE != noble
+
+linux-generic-hwe-24.04:
+  arch: amd64
+  when:
+   - DIB_RELEASE = noble

--- a/elements/cc-ubuntu24.04-hwe/package-installs.yaml
+++ b/elements/cc-ubuntu24.04-hwe/package-installs.yaml
@@ -1,9 +1,7 @@
-linux-image-generic:
-   arch: amd64
-   when:
-    - DIB_RELEASE != noble
-
 linux-generic-hwe-24.04:
-  arch: amd64
-  when:
-   - DIB_RELEASE = noble
+# uninstall all kernel 6.8 related stuff
+# workaround for linux-image-generic being installed by `ubuntu` element
+# and `linux-generic` being installed by cc-common element
+linux-*-6.8*-generic:
+  phase: post-install.d
+  uninstall: True


### PR DESCRIPTION
We dicovered that the 6.8 kernels that ship with ubuntu24.04 (at least 6.8.0-47 - 6.8.0-53), have a panic with the amdgpu kernel module when an AMD MI100 gpu is present on the system. The panic is shown in the dmesg logs from boot up, but causes an infinite hang on shutdown/reboot, due as udev also fails.

This bug appears to be fixed in 6.10, see:
https://lore.kernel.org/dri-devel/20240413213708.3427038-1-alexander.deucher@amd.com/

and we can get 6.11 by installing ubuntu's hwe kernel.

TODO: this fix causes both linux-image-generic, AND linux-image-hwe-24.04 to be installed, due to the inclusion of linux-image-generic under package-installs in our "ancestor" element, "ubuntu". The only real penalty being and extra 300mb of disk space taken, but should fix this before releasing to users.