### PR TITLE
Set default bootloader arguments, removing nomodeset and nofb

### DIFF
--- a/elements/cc-common/environment.d/00-cc-base
+++ b/elements/cc-common/environment.d/00-cc-base
@@ -4,4 +4,4 @@
 export DIB_GRUB_TIMEOUT=0
 
 # set default cmdline
-# DIB_BOOTLOADER_DEFAULT_CMDLINE="console=tty0 console=ttyS0,115200 pci=realloc=off"
+DIB_BOOTLOADER_DEFAULT_CMDLINE="gfxpayload=text pci=realloc=off"

--- a/elements/cc-common/environment.d/00-cc-base
+++ b/elements/cc-common/environment.d/00-cc-base
@@ -3,5 +3,14 @@
 # speed up boot times
 export DIB_GRUB_TIMEOUT=0
 
-# set default cmdline
+# DIB_BOOTLOADER_DEFAULT_CMDLINE sets parameters that are appended to the
+# GRUB_CMDLINE_LINUX_DEFAULT values in grub.cfg configuration.
+# defaults to nofb nomodeset gfxpayload=text.
+# - nofb: removed, appears to be a no-op for ~20 years??
+# - nomodeset: removed, causes all sorts of issues with amdgpu,
+#              and can cause excessive on some baremetal servers!
+# - gfxpayload=text: kept; probably ok, tells grub not to leave it at `auto`,
+#                    and only impacts what video drivers load
+# - pci=realloc=off: added needed to handle badness on ubuntu with ubuntu and multi-gpus
+#                    centos distros have it turned off already
 DIB_BOOTLOADER_DEFAULT_CMDLINE="gfxpayload=text pci=realloc=off"

--- a/elements/cc-ubuntu-cuda/environment.d/90-linux-cmdline
+++ b/elements/cc-ubuntu-cuda/environment.d/90-linux-cmdline
@@ -6,8 +6,3 @@ fi
 set -eu
 set -x
 set -o pipefail
-
-# pci=realloc=off is a fix for A100 nodes which fail to load Nvidia drivers
-# if 4 or more GPUs are installed
-DIB_BOOTLOADER_DEFAULT_CMDLINE="${DIB_BOOTLOADER_DEFAULT_CMDLINE} pci=realloc=off"
-

--- a/elements/cc-ubuntu-cuda/environment.d/90-linux-cmdline
+++ b/elements/cc-ubuntu-cuda/environment.d/90-linux-cmdline
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-    set -x
-fi
-set -eu
-set -x
-set -o pipefail

--- a/elements/cc-ubuntu24.04-hwe/environment.d/01-cmdline-defaults
+++ b/elements/cc-ubuntu24.04-hwe/environment.d/01-cmdline-defaults
@@ -16,15 +16,3 @@ export DIB_GRUB_TIMEOUT=0
 # Defaults to True, but only matters for VMs with some flaky hypervisors.
 # Leaving it out unless we observe issues, can roll back
 export DIB_NO_TIMER_CHECK='False'
-
-# DIB_BOOTLOADER_DEFAULT_CMDLINE sets parameters that are appended to the 
-# GRUB_CMDLINE_LINUX_DEFAULT values in grub.cfg configuration. 
-# defaults to nofb nomodeset gfxpayload=text.
-# - nofb: removed, appears to be a no-op for ~20 years??
-# - nomodeset: removed, causes all sorts of issues with amdgpu, 
-#              and can cause excessive on some baremetal servers!
-# - gfxpayload=text: kept; probably ok, tells grub not to leave it at `auto`, 
-#                    and only impacts what video drivers load
-# - pci=realloc=off: added needed to handle badness on ubuntu with ubuntu and multi-gpus
-#                    centos distros have it turned off already
-export DIB_BOOTLOADER_DEFAULT_CMDLINE="gfxpayload=text pci=realloc=off"


### PR DESCRIPTION
After updating these I verified by mounting the raw image and inspecting `/mnt/boot/grub/grub.cfg` for the new boot args:
```
linux   /boot/vmlinuz-6.8.0-55-generic root=LABEL=cloudimg-rootfs ro  console=tty0 console=ttyS0,115200 no_timer_check gfxpayload=text pci=realloc=off
```

`nofb` and `nomodeset` have been removed, with `gfxpayload=text pci=realloc=off` set.

The previous config was set with:
```
linux   /boot/vmlinuz-6.8.0-55-generic root=LABEL=cloudimg-rootfs ro  console=tty0 console=ttyS0,115200 no_timer_check nofb nomodeset gfxpayload=text
```

I also checked for the presence of `linux-image-generic`:
```
$ dpkg-query --admindir=/mnt/var/lib/dpkg -W linux-image-generic
linux-image-generic	6.8.0-55.57
```

I only built ubuntu24.04 so far to check this. Not sure if I should be building something else to verify these.

I haven't pushed these changes to glance and booted a node to verify on actual hardware. Should we do that before merging? Or do that once we get the other image changes in (e.g. AMD ROCm updates)?