### PR TITLE
[very WIP / draft!] concurrent futures for better parallelism

### DIFF
--- a/build_image_manual.py
+++ b/build_image_manual.py
@@ -1,0 +1,131 @@
+import subprocess
+import yaml
+from time import perf_counter
+from pathlib import Path
+import logging
+from dataclasses import dataclass, field
+from collections.abc import Mapping
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+class ImageBuildException(BaseException):
+    pass
+
+
+def build_an_image(image_name, arch, elements, envs):
+    build_path = Path("/opt/scratch/cc-images/build")
+
+    cache_path = build_path.joinpath("cache",image_name)
+    #ensure cache_path exists
+    cache_path.mkdir(parents=True, exist_ok=True)
+
+    image_build_dir = build_path.joinpath("images")
+    #ensure image_build_dir exists
+    image_build_dir.mkdir(parents=True, exist_ok=True)
+
+    image_name_path = image_build_dir.joinpath(image_name).as_posix()
+    logfile = image_build_dir.joinpath(f"{image_name}.log")
+    logfile.unlink(missing_ok=True)
+
+    elements_path = Path.cwd().joinpath("elements")
+
+    args = []
+    args.extend(["-a", arch])
+    args.extend(["-o", image_name_path])
+    args.extend(["--logfile", logfile.as_posix()])
+    args.extend(["-t", "raw,qcow2"])
+    args.extend(["--qemu-img-options", "compression_type=zstd"])
+
+    args.extend(elements)
+
+    env = {
+        "DIB_IMAGE_CACHE": cache_path,
+        "ELEMENTS_PATH": elements_path.as_posix(),
+    }
+    env.update(envs)
+
+    logging.info(f"starting build for {image_name}")
+
+    build_start_time_s = perf_counter()
+    try:
+        result = subprocess.run(
+            shell=True,
+            capture_output=True,
+            check=True,
+            executable=".venv/bin/disk-image-create",
+            args=args,
+            env=env,
+        )
+    except subprocess.CalledProcessError as ex:
+        raise ImageBuildException(ex.stderr)
+    else:
+        build_end_time_s = perf_counter()
+        elapsed_time_s = build_end_time_s - build_start_time_s
+        logging.info(f"Completed build for {image_name} in {elapsed_time_s} seconds")
+        return {"returncode": result.returncode, "duration": elapsed_time_s}
+
+
+
+def load_images_to_build(yaml_path):
+    with open("images_to_build.yaml") as f:
+        image_defs = yaml.safe_load(f)
+
+    images_to_build={}
+    for key, values in image_defs.items():
+        if str.startswith(key, "x-"):
+            """skip template only entries"""
+            continue
+
+
+
+        elements = set(values.get("elements"))
+        extra_elements = set(values.get("extra_elements", []))
+        elements.update(extra_elements)
+
+
+        images_to_build[key]={
+            "arch": values.get("arch"),
+            "elements": list(elements),
+            "envs": values.get("envs")
+        }
+
+    return images_to_build
+
+
+
+
+def main():
+    logging.basicConfig(level=logging.DEBUG)
+
+    images_to_build = load_images_to_build("images_to_build.yaml")
+
+
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        tasks = {}
+        for name, values in images_to_build.items():
+            if not name == "cc-rocky-9":
+                continue
+
+            kwargs = {
+                "image_name": name,
+                "arch": values.get("arch"),
+                "elements": values.get("elements"),
+                "envs": values.get("envs"),
+            }
+            future = executor.submit(build_an_image, **kwargs)
+            tasks[future] = kwargs
+
+        logging.info('Waiting for tasks to complete')
+
+        for future in as_completed(tasks):
+            args = tasks[future]
+            image_name = args.get("image_name")
+            try:
+                result = future.result()
+            except ImageBuildException as ex:
+                logging.warning(f"{image_name} did not build successfully, with error {ex}")
+
+
+if __name__ == "__main__":
+    main()

--- a/images_to_build.yaml
+++ b/images_to_build.yaml
@@ -1,0 +1,82 @@
+---
+centos8-stream:
+  arch: amd64
+  elements:
+    - vm
+    - block-device-efi
+    - centos
+  envs:
+    DIB_RELEASE: 8-stream
+centos9-stream:
+  arch: amd64
+  elements:
+    - vm
+    - block-device-efi
+    - centos
+  envs:
+    DIB_RELEASE: 9-stream
+
+x-rocky-elements: &rocky-elements
+  - vm
+  - block-device-efi
+  - rocky-container
+rocky8:
+  arch: amd64
+  elements: *rocky-elements
+  envs:
+    DIB_RELEASE: "8"
+    DIB_CONTAINERFILE_RUNTIME_ROOT: "1"
+rocky9: &rocky9
+  arch: amd64
+  elements: *rocky-elements
+  envs:
+    DIB_RELEASE: "9"
+    DIB_CONTAINERFILE_RUNTIME_ROOT: "1"
+
+### Currently doesn't build
+# cc-rocky-9:
+#   <<: *rocky9
+#   extra_elements:
+#     - cc-common
+
+### just a shortcut, this could be expanded for more verbosity
+x-ubuntu-elements: &ubuntu-elements
+  - vm
+  - block-device-efi
+  - ubuntu
+x-ubuntu-base: &ubuntu-base
+  arch: amd64
+  elements: *ubuntu-elements
+ubuntu18.04:
+  <<: *ubuntu-base
+  envs:
+    DIB_RELEASE: "bionic"
+    DIB_DISTRO_VERSION: "18.04"
+ubuntu20.04: &ubuntu-focal
+  <<: *ubuntu-base
+  envs:
+    DIB_RELEASE: "focal"
+    DIB_DISTRO_VERSION: "20.04"
+ubuntu22.04: &ubuntu-jammy
+  <<: *ubuntu-base
+  envs:
+    DIB_RELEASE: "jammy"
+    DIB_DISTRO_VERSION: "22.04"
+cc-ubuntu20.04:
+  <<: *ubuntu-focal
+  extra_elements:
+    - cc-common
+cc-ubuntu22.04:
+  <<: *ubuntu-jammy
+  extra_elements:
+    - cc-common
+cc-ubuntu20.04-cuda:
+  <<: *ubuntu-focal
+  extra_elements:
+    - cc-common
+    - cc-ubuntu-cuda
+cc-ubuntu22.04-cuda:
+  <<: *ubuntu-jammy
+  extra_elements:
+    - cc-common
+    - cc-ubuntu-cuda


### PR DESCRIPTION
minimal proof of concept for defining all images in a yaml file, then building in parallel with concurrent futures.
On a fast multicore system, this can build all supported images in under 10 minutes.

Because the "expensive" operation is the disk-image-create shell script, we have a lot of freedom in our approach to orchestrating it, and have no real need for a complex python invocation if we decide some other approach is better, even just a series of shell script invocations in CI, with a final bit of python glue to set the right metadata.

