### PR TITLE
Adds dib-lint with github job, various cleanup based on dib-lint sugg…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,52 @@
+on:
+  pull_request:
+
+jobs:
+  dib-lint:
+    name: Run dib-lint
+    runs-on: ubuntu-latest
+
+    env:
+      ELEMENTS_DIR: elements
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: Create & activate venv, install dib-lint
+        shell: bash
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+          pip install diskimage-builder
+
+      - name: Add dummy README.rst where missing
+        shell: bash
+        run: |
+          for d in elements/*; do
+            if [[ -d "$d" && ! -f "$d/README.rst" ]]; then
+              echo "Empty README for dib-lint" > "$d/README.rst"
+            fi
+          done
+
+      - name: Run dib-lint
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          dib-lint
+
+      # (Optional) clean up dummy READMEs, not strictly needed since the runner workspace is ephemeral
+      # - name: Remove dummy README.rst
+      #   shell: bash
+      #   run: |
+      #     for d in elements/*; do
+      #       [[ -f "$d/README.rst" && $(git ls-files --error-unmatch "$d/README.rst" 2>/dev/null) == "" ]] \
+      #         && rm "$d/README.rst"
+      #     done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,13 +19,10 @@ jobs:
           python-version: '3.x'
           cache: 'pip'
 
-      - name: Create & activate venv, install dib-lint
-        shell: bash
+      - name: Install dev dependencies
         run: |
-          python -m venv .venv
-          source .venv/bin/activate
           pip install --upgrade pip
-          pip install diskimage-builder
+          pip install .[dev]
 
       - name: Add dummy README.rst where missing
         shell: bash
@@ -39,7 +36,6 @@ jobs:
       - name: Run dib-lint
         shell: bash
         run: |
-          source .venv/bin/activate
           dib-lint
 
       # (Optional) clean up dummy READMEs, not strictly needed since the runner workspace is ephemeral

--- a/elements/cc-centos-cuda/environment.d/50-centos-cuda-env
+++ b/elements/cc-centos-cuda/environment.d/50-centos-cuda-env
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # The 5XX and higher drivers have issues on some of our older GPUs.
 # The 470 driver seems to work just fine everywhere
 #export DIB_NVIDIA_DRIVER_VERSION=latest-dkms

--- a/elements/cc-centos-cuda/pre-install.d/50-cuda-repository
+++ b/elements/cc-centos-cuda/pre-install.d/50-cuda-repository
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-  set -x
+    set -x
 fi
 set -eu
 set -x
@@ -11,6 +11,6 @@ release="rhel${DIB_RELEASE%-*}"
 
 # Add Nvidia's RHEL repo, which contains driver and CUDA packages
 ${YUM} \
-  config-manager -y \
-  --add-repo \
-  "https://developer.download.nvidia.com/compute/cuda/repos/${release}/$(uname -m)/cuda-${release}.repo"
+    config-manager -y \
+    --add-repo \
+    "https://developer.download.nvidia.com/compute/cuda/repos/${release}/$(uname -m)/cuda-${release}.repo"

--- a/elements/cc-centos/element-deps
+++ b/elements/cc-centos/element-deps
@@ -1,3 +1,3 @@
-centos
 cc-common
+centos
 disable-selinux

--- a/elements/cc-centos/post-install.d/02-update-dhcp-timeout
+++ b/elements/cc-centos/post-install.d/02-update-dhcp-timeout
@@ -8,7 +8,7 @@ set -o pipefail
 
 # Change the DHCP timeout to a 30 seconds value.
 if [[ -f "/etc/dhcp/dhclient.conf" ]]; then
-  sed -i "s/timeout.*/timeout 30;/g" /etc/dhcp/dhclient.conf
+    sed -i "s/timeout.*/timeout 30;/g" /etc/dhcp/dhclient.conf
 else
-  echo "timeout 300;" > /etc/dhcp/dhclient.d/cc-timeout.conf
+    echo "timeout 300;" > /etc/dhcp/dhclient.d/cc-timeout.conf
 fi

--- a/elements/cc-centos/post-install.d/99-centos-motd
+++ b/elements/cc-centos/post-install.d/99-centos-motd
@@ -9,8 +9,8 @@ set -o pipefail
 # add our custom messages: centos has them in profile.d
 # and they must end with .sh
 if [ -d "/etc/profile.d/" ]; then
-  for file in /etc/custom-motd/*; do
-    filename=$(basename "$file")
-    cp "$file" "/etc/profile.d/${filename}.sh"
-  done
+    for file in /etc/custom-motd/*; do
+        filename=$(basename "$file")
+        cp "$file" "/etc/profile.d/${filename}.sh"
+    done
 fi

--- a/elements/cc-centos/pre-install.d/10-package-repositories
+++ b/elements/cc-centos/pre-install.d/10-package-repositories
@@ -14,11 +14,11 @@ ${YUM} install -y "https://yum.puppet.com/puppet-release-el-${upstream_version}.
 # Extra Packages for Enterprise Linux repository
 ${YUM} install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${upstream_version}.noarch.rpm"
 if [[ "${upstream_version}" -ge 9 ]]; then
-  powertools_repo=crb
+    powertools_repo=crb
 else
-  powertools_repo=powertools
+    powertools_repo=powertools
 fi
 
 if [[ "${upstream_version}" -ge 8 ]]; then
-  ${YUM} config-manager --set-enabled "${powertools_repo}"
+    ${YUM} config-manager --set-enabled "${powertools_repo}"
 fi

--- a/elements/cc-centos9-stream-cuda/element-deps
+++ b/elements/cc-centos9-stream-cuda/element-deps
@@ -1,3 +1,3 @@
-centos
 cc-common
+centos
 disable-selinux

--- a/elements/cc-centos9-stream-cuda/environment.d/00-centos-env
+++ b/elements/cc-centos9-stream-cuda/environment.d/00-centos-env
@@ -1,3 +1,1 @@
-#!/bin/bash
-
 export DIB_RELEASE=9-stream

--- a/elements/cc-centos9-stream-cuda/environment.d/50-centos-cuda-env
+++ b/elements/cc-centos9-stream-cuda/environment.d/50-centos-cuda-env
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # The 5XX and higher drivers have issues on some of our older GPUs.
 # The 470 driver seems to work just fine everywhere
 #export DIB_NVIDIA_DRIVER_VERSION=latest-dkms

--- a/elements/cc-centos9-stream-cuda/post-install.d/02-update-dhcp-timeout
+++ b/elements/cc-centos9-stream-cuda/post-install.d/02-update-dhcp-timeout
@@ -8,7 +8,7 @@ set -o pipefail
 
 # Change the DHCP timeout to a 30 seconds value.
 if [[ -f "/etc/dhcp/dhclient.conf" ]]; then
-  sed -i "s/timeout.*/timeout 30;/g" /etc/dhcp/dhclient.conf
+    sed -i "s/timeout.*/timeout 30;/g" /etc/dhcp/dhclient.conf
 else
-  echo "timeout 300;" > /etc/dhcp/dhclient.d/cc-timeout.conf
+    echo "timeout 300;" > /etc/dhcp/dhclient.d/cc-timeout.conf
 fi

--- a/elements/cc-centos9-stream-cuda/pre-install.d/10-package-repositories
+++ b/elements/cc-centos9-stream-cuda/pre-install.d/10-package-repositories
@@ -14,11 +14,11 @@ ${YUM} install -y "https://yum.puppet.com/puppet-release-el-${upstream_version}.
 # Extra Packages for Enterprise Linux repository
 ${YUM} install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${upstream_version}.noarch.rpm"
 if [[ "${upstream_version}" -ge 9 ]]; then
-  powertools_repo=crb
+    powertools_repo=crb
 else
-  powertools_repo=powertools
+    powertools_repo=powertools
 fi
 
 if [[ "${upstream_version}" -ge 8 ]]; then
-  ${YUM} config-manager --set-enabled "${powertools_repo}"
+    ${YUM} config-manager --set-enabled "${powertools_repo}"
 fi

--- a/elements/cc-centos9-stream-cuda/pre-install.d/50-cuda-repository
+++ b/elements/cc-centos9-stream-cuda/pre-install.d/50-cuda-repository
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-  set -x
+    set -x
 fi
 set -eu
 set -x
@@ -11,6 +11,6 @@ release="rhel${DIB_RELEASE%-*}"
 
 # Add Nvidia's RHEL repo, which contains driver and CUDA packages
 ${YUM} \
-  config-manager -y \
-  --add-repo \
-  "https://developer.download.nvidia.com/compute/cuda/repos/${release}/$(uname -m)/cuda-${release}.repo"
+    config-manager -y \
+    --add-repo \
+    "https://developer.download.nvidia.com/compute/cuda/repos/${release}/$(uname -m)/cuda-${release}.repo"

--- a/elements/cc-centos9-stream/environment.d/00-centos-env
+++ b/elements/cc-centos9-stream/environment.d/00-centos-env
@@ -1,3 +1,1 @@
-#!/bin/bash
-
 export DIB_RELEASE=9-stream

--- a/elements/cc-common/bin/cc-disable-firewalld-sg
+++ b/elements/cc-common/bin/cc-disable-firewalld-sg
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+# dib-lint: disable=sete setu setpipefail dibdebugtrace
+
 REGION=$(cc-read-vendordata "region")
 
 # Disable firewalld on regions using security groups.
 # For now that's KVM@TACC.
 if [ "${REGION}" = "KVM@TACC" ]; then
-  sudo systemctl disable firewalld --now
+    sudo systemctl disable firewalld --now
 fi

--- a/elements/cc-common/bin/cc-generate-openrc
+++ b/elements/cc-common/bin/cc-generate-openrc
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+# dib-lint: disable=sete setu setpipefail dibdebugtrace
+
 OPENRC=$(cc-read-vendordata "openrc")
 
 if [ "${OPENRC}" != "null" ]; then
-  cc-read-vendordata "openrc" >  /home/cc/openrc
-  sed -i 's/^ *//g' /home/cc/openrc
+    cc-read-vendordata "openrc" > /home/cc/openrc
+    sed -i 's/^ *//g' /home/cc/openrc
 fi

--- a/elements/cc-common/bin/cc-load-public-keys
+++ b/elements/cc-common/bin/cc-load-public-keys
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# dib-lint: disable=sete setu setpipefail dibdebugtrace
+
 SSH_KEYPAIRS=$(cc-read-vendordata "ssh_keypairs" | tr -d "\n")
 KEYPAIRS=$(python3 -c "import json; print('\n'.join(obj['keypair']['public_key'] for obj in json.loads('$SSH_KEYPAIRS', strict=False)))")
 

--- a/elements/cc-common/bin/cc-read-vendordata
+++ b/elements/cc-common/bin/cc-read-vendordata
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# dib-lint: disable=sete setu setpipefail dibdebugtrace
+
 PARAM=$1
 
 OPENSTACK_VENDOR_DATA_2='http://169.254.169.254/openstack/latest/vendor_data2.json'

--- a/elements/cc-common/element-deps
+++ b/elements/cc-common/element-deps
@@ -1,9 +1,9 @@
 block-device-efi
+cc-firewall
+cc-manifest
 cc-rclone
 cc-snapshot
-cc-firewall
-vm
-install-static
-install-bin
 cc-timesync
-cc-manifest
+install-bin
+install-static
+vm

--- a/elements/cc-common/environment.d/00-cc-base
+++ b/elements/cc-common/environment.d/00-cc-base
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # speed up boot times
 export DIB_GRUB_TIMEOUT=0
 

--- a/elements/cc-common/post-install.d/99-motd
+++ b/elements/cc-common/post-install.d/99-motd
@@ -18,5 +18,5 @@ rm -f /etc/update-motd.d/95-hwe-eol
 
 # add our custom messages
 if [ -d "/etc/update-motd.d/" ]; then
-  cp /etc/custom-motd/* /etc/update-motd.d/
+    cp /etc/custom-motd/* /etc/update-motd.d/
 fi

--- a/elements/cc-common/static/etc/custom-motd/01-get-help
+++ b/elements/cc-common/static/etc/custom-motd/01-get-help
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# dib-lint: disable=sete setu setpipefail dibdebugtrace
+
 cat << EOF
 
 GETTING HELP

--- a/elements/cc-common/static/etc/custom-motd/02-storage-notes
+++ b/elements/cc-common/static/etc/custom-motd/02-storage-notes
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# dib-lint: disable=sete setu setpipefail dibdebugtrace indent
+
 cat << EOF
 
 DATA MANAGEMENT

--- a/elements/cc-common/static/etc/custom-motd/03-firewall-status
+++ b/elements/cc-common/static/etc/custom-motd/03-firewall-status
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# dib-lint: disable=sete setu setpipefail dibdebugtrace
+
 cat << EOF
 
 FIREWALL STATUS

--- a/elements/cc-manifest/cleanup.d/50-output-provenance-file
+++ b/elements/cc-manifest/cleanup.d/50-output-provenance-file
@@ -4,7 +4,7 @@
 # var "DIB_CC_PROVENANCE" to a file stored in the image output directory.
 
 if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-  set -x
+    set -x
 fi
 set -eu
 set -o pipefail

--- a/elements/cc-manifest/post-install.d/50-provenance
+++ b/elements/cc-manifest/post-install.d/50-provenance
@@ -5,7 +5,7 @@
 # information about the base image if it is snapshotted later.
 
 if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-  set -x
+    set -x
 fi
 set -eu
 set -o pipefail

--- a/elements/cc-openstack-clients/post-install.d/50-install-openstack-clients
+++ b/elements/cc-openstack-clients/post-install.d/50-install-openstack-clients
@@ -6,7 +6,6 @@ fi
 set -eu
 set -o pipefail
 
-
 TOOLKIT_REQUIREMENTS_URL="https://raw.githubusercontent.com/ChameleonCloud/cc-toolkit/main/requirements.txt"
 
 VENV_PATH_BASE=/opt/chameleon

--- a/elements/cc-rclone/bin/cc-mount-object-store
+++ b/elements/cc-rclone/bin/cc-mount-object-store
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+# dib-lint: disable=sete setu setpipefail dibdebugtrace
+
 REGION=$(cc-read-vendordata "region")
 if [ "${REGION}" = "KVM@TACC" ]; then
-  echo "${REGION} does not support object store mounts!"
-  exit 1
+    echo "${REGION} does not support object store mounts!"
+    exit 1
 fi
 
 MOUNT_BASE="$HOME/cc_my_mounting_point"
@@ -14,128 +16,128 @@ PID_DIR="$HOME/.rclone/pids"
 mkdir -p "${LOG_DIR}" "${PID_DIR}"
 
 check_container_name() {
-  if [ -z "${1}" ]; then
-    echo "Error: Container name not provided"
-    echo "Usage: ${0} ${2} <container-name>"
-    return 1
-  fi
-  return 0
+    if [ -z "${1}" ]; then
+        echo "Error: Container name not provided"
+        echo "Usage: ${0} ${2} <container-name>"
+        return 1
+    fi
+    return 0
 }
 
 start() {
-  check_container_name "${1}" "start" || return 1
-  local container_name="${1}"
+    check_container_name "${1}" "start" || return 1
+    local container_name="${1}"
 
-  local mount_point="${MOUNT_BASE}/${container_name}"
-  local pid_file="${PID_DIR}/${container_name}.pid"
-  local log_file="${LOG_DIR}/${container_name}.log"
+    local mount_point="${MOUNT_BASE}/${container_name}"
+    local pid_file="${PID_DIR}/${container_name}.pid"
+    local log_file="${LOG_DIR}/${container_name}.log"
 
-  if [ -f "${pid_file}" ]; then
-    echo "Mount for ${container_name} already exists (PID: $(cat "${pid_file}"))"
-    return 1
-  fi
+    if [ -f "${pid_file}" ]; then
+        echo "Mount for ${container_name} already exists (PID: $(cat "${pid_file}"))"
+        return 1
+    fi
 
-  mkdir -p "${mount_point}"
-  if [ ! -f "${mount_point}/THIS_IS_NOT_MOUNTED" ]; then
-    touch "${mount_point}/THIS_IS_NOT_MOUNTED"
-  fi
-  rclone mount "${RCLONE_REMOTE}":"${container_name}" "${mount_point}" \
-    --daemon \
-    --allow-non-empty \
-    --log-level INFO \
-    --log-file="${log_file}" &
+    mkdir -p "${mount_point}"
+    if [ ! -f "${mount_point}/THIS_IS_NOT_MOUNTED" ]; then
+        touch "${mount_point}/THIS_IS_NOT_MOUNTED"
+    fi
+    rclone mount "${RCLONE_REMOTE}":"${container_name}" "${mount_point}" \
+        --daemon \
+        --allow-non-empty \
+        --log-level INFO \
+        --log-file="${log_file}" &
 
-  # Wait a moment for the process to start
-  sleep 2
+    # Wait a moment for the process to start
+    sleep 2
 
-  local pid=$(pgrep -f "rclone mount ${RCLONE_REMOTE}:${container_name} ${mount_point}")
+    local pid=$(pgrep -f "rclone mount ${RCLONE_REMOTE}:${container_name} ${mount_point}")
 
-  if [ -n "${pid}" ]; then
-    echo ${pid} > "${pid_file}"
-    echo "Started mount for ${container_name} (PID: ${pid})"
-  else
-    echo "Failed to start mount for ${container_name}"
-    return 1
-  fi
+    if [ -n "${pid}" ]; then
+        echo ${pid} > "${pid_file}"
+        echo "Started mount for ${container_name} (PID: ${pid})"
+    else
+        echo "Failed to start mount for ${container_name}"
+        return 1
+    fi
 }
 
 stop() {
-  check_container_name "${1}" "stop" || return 1
-  local container_name="${1}"
+    check_container_name "${1}" "stop" || return 1
+    local container_name="${1}"
 
-  local pid_file="${PID_DIR}/${container_name}.pid"
-  local mount_point="${MOUNT_BASE}/${container_name}"
+    local pid_file="${PID_DIR}/${container_name}.pid"
+    local mount_point="${MOUNT_BASE}/${container_name}"
 
-  if [ ! -f "${pid_file}" ]; then
-    echo "No mount found for ${container_name}. Is it running?"
-    return 1
-  fi
+    if [ ! -f "${pid_file}" ]; then
+        echo "No mount found for ${container_name}. Is it running?"
+        return 1
+    fi
 
-  local pid=$(cat "${pid_file}")
-  kill "${pid}"
-  fusermount -uz "${mount_point}"
-  rm "${pid_file}"
-  echo "Stopped mount for ${container_name}"
+    local pid=$(cat "${pid_file}")
+    kill "${pid}"
+    fusermount -uz "${mount_point}"
+    rm "${pid_file}"
+    echo "Stopped mount for ${container_name}"
 }
 
 status() {
-  check_container_name "${1}" "status" || return 1
-  local container_name="${1}"
+    check_container_name "${1}" "status" || return 1
+    local container_name="${1}"
 
-  local pid_file="${PID_DIR}/${container_name}.pid"
-  local mount_point="${MOUNT_BASE}/${container_name}"
+    local pid_file="${PID_DIR}/${container_name}.pid"
+    local mount_point="${MOUNT_BASE}/${container_name}"
 
-  if [ -f "${pid_file}" ]; then
-    local pid=$(cat "${pid_file}")
-    if kill -0 "${pid}" 2>/dev/null; then
-      echo "Mount for ${container_name} is active (PID: ${pid})"
-      echo "Mount point: ${mount_point}"
+    if [ -f "${pid_file}" ]; then
+        local pid=$(cat "${pid_file}")
+        if kill -0 "${pid}" 2>/dev/null; then
+            echo "Mount for ${container_name} is active (PID: ${pid})"
+            echo "Mount point: ${mount_point}"
+        else
+            echo "Mount for ${container_name} exists but process is not running"
+            echo "You may want to clean up the stale PID file: ${pid_file}"
+        fi
     else
-      echo "Mount for ${container_name} exists but process is not running"
-      echo "You may want to clean up the stale PID file: ${pid_file}"
+            echo "No mount found for ${container_name}. Is it running?"
     fi
-  else
-      echo "No mount found for ${container_name}. Is it running?"
-  fi
 }
 
 list_mounts() {
-  echo "Active mounts:"
-  local found_mounts=false
-  for pid_file in "${PID_DIR}"/*.pid; do
-    if [ -f "${pid_file}" ]; then
-      local container_name=$(basename "${pid_file}" .pid)
-      local pid=$(cat "${pid_file}")
-      local mount_point="${MOUNT_BASE}/${container_name}"
-      if kill -0 "${pid}" 2>/dev/null; then
-        printf "%-20s - PID: %-6s - Mount: %s\n" "${container_name}" "${pid}" "${mount_point}"
-        found_mounts=true
-      else
-        printf "%-20s - Stale PID: %-6s - NOT MOUNTED!\n" "$container_name" "${pid}"
-      fi
-    fi
-  done
+    echo "Active mounts:"
+    local found_mounts=false
+    for pid_file in "${PID_DIR}"/*.pid; do
+        if [ -f "${pid_file}" ]; then
+            local container_name=$(basename "${pid_file}" .pid)
+            local pid=$(cat "${pid_file}")
+            local mount_point="${MOUNT_BASE}/${container_name}"
+            if kill -0 "${pid}" 2>/dev/null; then
+                printf "%-20s - PID: %-6s - Mount: %s\n" "${container_name}" "${pid}" "${mount_point}"
+                found_mounts=true
+            else
+                printf "%-20s - Stale PID: %-6s - NOT MOUNTED!\n" "$container_name" "${pid}"
+            fi
+        fi
+    done
 
-  if [ "${found_mounts}" = false ]; then
-    echo "  No active mounts found"
-  fi
+    if [ "${found_mounts}" = false ]; then
+        echo "    No active mounts found"
+    fi
 }
 
 case "${1}" in
-  start)
-    start "${2}"
-    ;;
-  stop)
-    stop "${2}"
-    ;;
-  status)
-    status "${2}"
-    ;;
-  list)
-    list_mounts
-    ;;
-  *)
-    echo "Usage: ${0} {start|stop|status|list} [<container-name>]"
-    exit 1
-    ;;
+    start)
+        start "${2}"
+        ;;
+    stop)
+        stop "${2}"
+        ;;
+    status)
+        status "${2}"
+        ;;
+    list)
+        list_mounts
+        ;;
+    *)
+        echo "Usage: ${0} {start|stop|status|list} [<container-name>]"
+        exit 1
+        ;;
 esac

--- a/elements/cc-rclone/bin/setup-cc-mount-object-store
+++ b/elements/cc-rclone/bin/setup-cc-mount-object-store
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+# dib-lint: disable=sete setu setpipefail dibdebugtrace
+
 exit_failure() {
-  echo "$(date '+%Y-%m-%d %H:%M:%S'): Failed to create object store mount!" >> cc_my_mounting_point.failure
+    echo "$(date '+%Y-%m-%d %H:%M:%S'): Failed to create object store mount!" >> cc_my_mounting_point.failure
 }
 
 trap 'exit_failure' EXIT
@@ -9,40 +11,40 @@ trap 'exit_failure' EXIT
 set -e
 
 if [ ! -f /home/cc/openrc ]; then
-  OPENRC=$(cc-read-vendordata "openrc")
-  if [ "${OPENRC}" != "null" ]; then
-    cc-read-vendordata "openrc" >  /home/cc/openrc
-    sed -i 's/^ *//g' /home/cc/openrc
-  else
-    echo "$(date '+%Y-%m-%d %H:%M:%S'): Unable to read OPENRC" >> /home/cc/cc_my_mounting_point.failure
-    exit 1
-  fi
+    OPENRC=$(cc-read-vendordata "openrc")
+    if [ "${OPENRC}" != "null" ]; then
+        cc-read-vendordata "openrc" > /home/cc/openrc
+        sed -i 's/^ *//g' /home/cc/openrc
+    else
+        echo "$(date '+%Y-%m-%d %H:%M:%S'): Unable to read OPENRC" >> /home/cc/cc_my_mounting_point.failure
+        exit 1
+    fi
 fi
 
 source /home/cc/openrc
 if [ -z "${OS_STORAGE_URL}" ]; then
-  echo "$(date '+%Y-%m-%d %H:%M:%S'): OS_STORAGE_URL was not set" >> /home/cc/cc_my_mounting_point.failure
-  REGION=$(cc-read-vendordata "region")
-  if [ "${REGION}" = "KVM@TACC" ]; then
-    echo "$(date '+%Y-%m-%d %H:%M:%S'): KVM@TACC does not have an object store available" >> /home/cc/cc_my_mounting_point.failure
-  fi
-  exit 1
+    echo "$(date '+%Y-%m-%d %H:%M:%S'): OS_STORAGE_URL was not set" >> /home/cc/cc_my_mounting_point.failure
+    REGION=$(cc-read-vendordata "region")
+    if [ "${REGION}" = "KVM@TACC" ]; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S'): KVM@TACC does not have an object store available" >> /home/cc/cc_my_mounting_point.failure
+    fi
+    exit 1
 fi
 
 EC2_STORAGE_ENDPOINT=${OS_STORAGE_URL%/swift*}
 EC2_CREDS="$(openstack ec2 credential list -f json 2>/dev/null)"
 if [ $? -eq 0 ] && [ ! -z "$output" ]; then
-  ACCESS_KEY=$(echo "$output" | jq -r '.[0].Access')
-  SECRET_KEY=$(echo "$output" | jq -r '.[0].Secret')
+    ACCESS_KEY=$(echo "$output" | jq -r '.[0].Access')
+    SECRET_KEY=$(echo "$output" | jq -r '.[0].Secret')
 else
-  EC2_CREDS="$(openstack ec2 credential create -f json 2>/dev/null)"
-  ACCESS_KEY=$(echo ${EC2_CREDS} | jq -r '.access')
-  SECRET_KEY=$(echo ${EC2_CREDS} | jq -r '.secret')
+    EC2_CREDS="$(openstack ec2 credential create -f json 2>/dev/null)"
+    ACCESS_KEY=$(echo ${EC2_CREDS} | jq -r '.access')
+    SECRET_KEY=$(echo ${EC2_CREDS} | jq -r '.secret')
 fi
 
 if [ -z "$EC2_STORAGE_ENDPOINT" ] || [ -z "$ACCESS_KEY" ] || [ -z "$SECRET_KEY" ]; then
-  echo "$(date '+%Y-%m-%d %H:%M:%S'): EC2 vars not set" >> /home/cc/cc_my_mounting_point.failure
-  exit 1
+    echo "$(date '+%Y-%m-%d %H:%M:%S'): EC2 vars not set" >> /home/cc/cc_my_mounting_point.failure
+    exit 1
 fi
 
 mkdir -p /home/cc/.config/rclone/

--- a/elements/cc-rclone/environment.d/00-rclone-env
+++ b/elements/cc-rclone/environment.d/00-rclone-env
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 export RCLONE_V="v1.69.1"
 export RCLONE_URL_BASE="https://github.com/rclone/rclone/releases/download/${RCLONE_V}"
 export RCLONE_AMD_DEB_URL="${RCLONE_URL_BASE}/rclone-${RCLONE_V}-linux-amd64.deb"

--- a/elements/cc-rclone/install.d/05-cc-rclone
+++ b/elements/cc-rclone/install.d/05-cc-rclone
@@ -10,38 +10,38 @@ OS="unknown"
 ARCH="unknown"
 
 case $(uname -m) in
-  x86_64|amd64) ARCH="amd" ;;
-  arm64|aarch64) ARCH="arm" ;;
-  *) echo "Unsupported architecture"; exit 1 ;;
+    x86_64|amd64) ARCH="amd" ;;
+    arm64|aarch64) ARCH="arm" ;;
+    *) echo "Unsupported architecture"; exit 1 ;;
 esac
 
 if [ -f /etc/debian_version ]; then
-  OS="ubuntu"
+    OS="ubuntu"
 elif [ -f /etc/centos-release ]; then
-  OS="centos"
+    OS="centos"
 else
-  echo "Unsupported operating system"
-  exit 1
+    echo "Unsupported operating system"
+    exit 1
 fi
 
 URL=""
 case "${OS}-${ARCH}" in
-  "ubuntu-amd")
-    [ -z "${RCLONE_AMD_DEB_URL}" ] && { echo "RCLONE_AMD_DEB_URL not set"; exit 1; }
-    URL="${RCLONE_AMD_DEB_URL}"
-    ;;
-  "ubuntu-arm")
-    [ -z "${RCLONE_ARM_DEB_URL}" ] && { echo "RCLONE_ARM_DEB_URL not set"; exit 1; }
-    URL="${RCLONE_ARM_DEB_URL}"
-    ;;
-  "centos-amd")
-    [ -z "${RCLONE_AMD_RPM_URL}" ] && { echo "RCLONE_AMD_RPM_URL not set"; exit 1; }
-    URL="${RCLONE_AMD_RPM_URL}"
-    ;;
-  *)
-    echo "Unsupported OS-architecture combination: ${OS}-${ARCH}"
-    exit 1
-    ;;
+    "ubuntu-amd")
+        [ -z "${RCLONE_AMD_DEB_URL}" ] && { echo "RCLONE_AMD_DEB_URL not set"; exit 1; }
+        URL="${RCLONE_AMD_DEB_URL}"
+        ;;
+    "ubuntu-arm")
+        [ -z "${RCLONE_ARM_DEB_URL}" ] && { echo "RCLONE_ARM_DEB_URL not set"; exit 1; }
+        URL="${RCLONE_ARM_DEB_URL}"
+        ;;
+    "centos-amd")
+        [ -z "${RCLONE_AMD_RPM_URL}" ] && { echo "RCLONE_AMD_RPM_URL not set"; exit 1; }
+        URL="${RCLONE_AMD_RPM_URL}"
+        ;;
+    *)
+        echo "Unsupported OS-architecture combination: ${OS}-${ARCH}"
+        exit 1
+        ;;
 esac
 
 FILENAME=$(basename "${URL}")
@@ -49,18 +49,18 @@ TMP_FILE="/tmp/${FILENAME}"
 
 echo "Downloading ${FILENAME}..."
 if ! curl -sL "${URL}" -o "${TMP_FILE}"; then
-  echo "Failed to download package"
-  exit 1
+    echo "Failed to download package"
+    exit 1
 fi
 
 echo "Installing ${FILENAME}..."
 case "${OS}" in
-  "ubuntu")
-    sudo dpkg -i "${TMP_FILE}"
-    ;;
-  "centos")
-    sudo rpm -i "${TMP_FILE}"
-    ;;
+    "ubuntu")
+        sudo dpkg -i "${TMP_FILE}"
+        ;;
+    "centos")
+        sudo rpm -i "${TMP_FILE}"
+        ;;
 esac
 
 rm -f "${TMP_FILE}"

--- a/elements/cc-ubuntu-cuda/environment.d/01-ubuntu-cuda-env
+++ b/elements/cc-ubuntu-cuda/environment.d/01-ubuntu-cuda-env
@@ -1,4 +1,2 @@
-#!/bin/bash
-
 export DIB_NVIDIA_KEYRING_PKG=cuda-keyring_1.0-1_all.deb
 export DIB_CUDA_VERSION=${DIB_CUDA_VERSION:-12}

--- a/elements/cc-ubuntu-cuda/extra-data.d/00-cuda-cache
+++ b/elements/cc-ubuntu-cuda/extra-data.d/00-cuda-cache
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-  set -x
+    set -x
 fi
 set -eu
 set -o pipefail
 
 if [[ ! -d "${DIB_IMAGE_CACHE}/cuda" ]]; then
-  mkdir -p "${DIB_IMAGE_CACHE}/cuda"
+    mkdir -p "${DIB_IMAGE_CACHE}/cuda"
 fi

--- a/elements/cc-ubuntu-cuda/extra-data.d/04-download-cuda-keyring-package
+++ b/elements/cc-ubuntu-cuda/extra-data.d/04-download-cuda-keyring-package
@@ -13,8 +13,8 @@ platform="$(uname -i)"
 keyring_pkg_url=https://developer.download.nvidia.com/compute/cuda/repos/ubuntu"$nvidia_release"/"$platform"/"${DIB_NVIDIA_KEYRING_PKG}"
 cached_pkg="${DIB_IMAGE_CACHE}/cuda/${DIB_NVIDIA_KEYRING_PKG}"
 if [[ ! -f "${cached_pkg}" ]]; then
-  echo "Nvidia keyring package not cached. Downloading a new copy..."
-  wget --show-progress -O "${cached_pkg}" "${keyring_pkg_url}"
+    echo "Nvidia keyring package not cached. Downloading a new copy..."
+    wget --show-progress -O "${cached_pkg}" "${keyring_pkg_url}"
 fi
 
 cp "${cached_pkg}" "${TMP_HOOKS_PATH}"

--- a/elements/cc-ubuntu20.04-cuda/element-deps
+++ b/elements/cc-ubuntu20.04-cuda/element-deps
@@ -1,2 +1,2 @@
-cc-ubuntu20.04
 cc-ubuntu-cuda
+cc-ubuntu20.04

--- a/elements/cc-ubuntu20.04-cuda11/element-deps
+++ b/elements/cc-ubuntu20.04-cuda11/element-deps
@@ -1,2 +1,2 @@
-cc-ubuntu20.04
 cc-ubuntu-cuda
+cc-ubuntu20.04

--- a/elements/cc-ubuntu20.04-cuda11/environment.d/99-cuda-version.sh
+++ b/elements/cc-ubuntu20.04-cuda11/environment.d/99-cuda-version.sh
@@ -1,3 +1,1 @@
-#!/bin/bash
-
 export DIB_CUDA_VERSION=11

--- a/elements/cc-ubuntu20.04/element-deps
+++ b/elements/cc-ubuntu20.04/element-deps
@@ -1,2 +1,2 @@
-ubuntu
 cc-common
+ubuntu

--- a/elements/cc-ubuntu20.04/environment.d/00-ubuntu-env
+++ b/elements/cc-ubuntu20.04/environment.d/00-ubuntu-env
@@ -1,4 +1,2 @@
-#!/bin/bash
-
 export DIB_RELEASE=focal
 export DIB_DISTRO_VERSION=20.04

--- a/elements/cc-ubuntu22.04-cuda/element-deps
+++ b/elements/cc-ubuntu22.04-cuda/element-deps
@@ -1,2 +1,2 @@
-cc-ubuntu22.04
 cc-ubuntu-cuda
+cc-ubuntu22.04

--- a/elements/cc-ubuntu22.04/element-deps
+++ b/elements/cc-ubuntu22.04/element-deps
@@ -1,2 +1,2 @@
-ubuntu
 cc-common
+ubuntu

--- a/elements/cc-ubuntu22.04/environment.d/00-ubuntu-env
+++ b/elements/cc-ubuntu22.04/environment.d/00-ubuntu-env
@@ -1,4 +1,2 @@
-#!/bin/bash
-
 export DIB_RELEASE=jammy
 export DIB_DISTRO_VERSION=22.04

--- a/elements/cc-ubuntu24.04-cuda/element-deps
+++ b/elements/cc-ubuntu24.04-cuda/element-deps
@@ -1,2 +1,2 @@
-cc-ubuntu24.04
 cc-ubuntu-cuda
+cc-ubuntu24.04

--- a/elements/cc-ubuntu24.04-cuda/environment.d/98-cuda-env
+++ b/elements/cc-ubuntu24.04-cuda/environment.d/98-cuda-env
@@ -1,3 +1,1 @@
-#!/bin/bash
-
 export DIB_NVIDIA_KEYRING_PKG=cuda-keyring_1.1-1_all.deb

--- a/elements/cc-ubuntu24.04-rocm/element-deps
+++ b/elements/cc-ubuntu24.04-rocm/element-deps
@@ -1,2 +1,2 @@
-ubuntu
 cc-common
+ubuntu

--- a/elements/cc-ubuntu24.04-rocm/environment.d/00-ubuntu-env
+++ b/elements/cc-ubuntu24.04-rocm/environment.d/00-ubuntu-env
@@ -1,4 +1,2 @@
-#!/bin/bash
-
 export DIB_RELEASE=noble
 export DIB_DISTRO_VERSION=24.04

--- a/elements/cc-ubuntu24.04-rocm/environment.d/01-cmdline-defaults
+++ b/elements/cc-ubuntu24.04-rocm/environment.d/01-cmdline-defaults
@@ -1,7 +1,4 @@
-#!/bin/bash
-
 # see https://github.com/openstack/diskimage-builder/tree/master/diskimage_builder/elements/bootloader
-
 
 # DIB_GRUB_TIMEOUT sets the grub menu timeout. It defaults to 5 seconds. Set this to 0 (no timeout) for fast boot times.
 export DIB_GRUB_TIMEOUT=0

--- a/elements/cc-ubuntu24.04/element-deps
+++ b/elements/cc-ubuntu24.04/element-deps
@@ -1,2 +1,2 @@
-ubuntu
 cc-common
+ubuntu

--- a/elements/cc-ubuntu24.04/environment.d/00-ubuntu-env
+++ b/elements/cc-ubuntu24.04/environment.d/00-ubuntu-env
@@ -1,4 +1,2 @@
-#!/bin/bash
-
 export DIB_RELEASE=noble
 export DIB_DISTRO_VERSION=24.04

--- a/elements/cuda/post-install.d/10-cuda-env
+++ b/elements/cuda/post-install.d/10-cuda-env
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
 cuda_config_path="/etc/profile.d/cuda-config.sh"
 
 cat > "${cuda_config_path}" <<- 'EOM'

--- a/elements/fpga-runtime-opencl/extra-data.d/10-download-board-package
+++ b/elements/fpga-runtime-opencl/extra-data.d/10-download-board-package
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-  set -x
+    set -x
 fi
 set -eu
 set -o pipefail
@@ -9,7 +9,7 @@ set -o pipefail
 BOARD_PACKAGE_LOCAL_ARCHIVE="${DIB_IMAGE_CACHE}/fpga/${DIB_FPGA_BOARD_PACAKGE_ARCHIVE_NAME}"
 
 if [[ ! -f "${BOARD_PACKAGE_LOCAL_ARCHIVE}" ]]; then
-  wget --show-progress -O "${BOARD_PACKAGE_LOCAL_ARCHIVE}" "${DIB_FPGA_BOARD_PACKAGE_ARCHIVE_URL}"
+    wget --show-progress -O "${BOARD_PACKAGE_LOCAL_ARCHIVE}" "${DIB_FPGA_BOARD_PACKAGE_ARCHIVE_URL}"
 fi
 
 cp "${BOARD_PACKAGE_LOCAL_ARCHIVE}" "${TMP_HOOKS_PATH}"

--- a/elements/fpga-runtime-opencl/extra-data.d/10-download-opencl-runtime
+++ b/elements/fpga-runtime-opencl/extra-data.d/10-download-opencl-runtime
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-  set -x
+    set -x
 fi
 set -eu
 set -o pipefail
@@ -9,7 +9,7 @@ set -o pipefail
 OPENCL_LOCAL_FILE="${DIB_IMAGE_CACHE}/fpga/${DIB_OPENCL_RUNFILE_NAME}"
 
 if [[ ! -f "${OPENCL_LOCAL_FILE}" ]]; then
-  wget --show-progress -O "${OPENCL_LOCAL_FILE}" "${DIB_OPENCL_RUNFILE_URL}"
+    wget --show-progress -O "${OPENCL_LOCAL_FILE}" "${DIB_OPENCL_RUNFILE_URL}"
 fi
 
 cp "${OPENCL_LOCAL_FILE}" "${TMP_HOOKS_PATH}"

--- a/elements/fpga-runtime-opencl/install.d/05-install-opencl-runtime
+++ b/elements/fpga-runtime-opencl/install.d/05-install-opencl-runtime
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-  set -x
+    set -x
 fi
+set -eu
+set -o pipefail
 set -o nounset
 set -o errexit
-set -o pipefail
 
 # Install Altera RTE
 install-packages install -y "/tmp/in_target.d/${DIB_OPENCL_RUNFILE_NAME}"

--- a/elements/fpga-runtime-quartus/extra-data.d/10-download-quartus-runfile
+++ b/elements/fpga-runtime-quartus/extra-data.d/10-download-quartus-runfile
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-  set -x
+    set -x
 fi
 set -eu
 set -o pipefail
@@ -10,7 +10,7 @@ QUARTUS_RUNFILE_NAME="QuartusProProgrammerSetup-${DIB_QUARTUS_VERSION}-linux.run
 QUARTUS_LOCAL_FILE="${DIB_IMAGE_CACHE}/fpga/${QUARTUS_RUNFILE_NAME}"
 
 if [[ ! -f "${QUARTUS_LOCAL_FILE}" ]]; then
-  wget --show-progress -O "${QUARTUS_LOCAL_FILE}" "${DIB_QUARTUS_RUNFILE_URL}"
+    wget --show-progress -O "${QUARTUS_LOCAL_FILE}" "${DIB_QUARTUS_RUNFILE_URL}"
 fi
 
 cp "${QUARTUS_LOCAL_FILE}" "${TMP_HOOKS_PATH}"

--- a/elements/fpga-runtime-quartus/install.d/04-install-quartus
+++ b/elements/fpga-runtime-quartus/install.d/04-install-quartus
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-  set -x
+    set -x
 fi
+set -eu
+set -x
+set -o pipefail
 set -o nounset
 set -o errexit
-set -o pipefail
 
 QUARTUS_ROOTDIR=/opt/intelFPGA_pro/"${DIB_QUARTUS_VERSION}"
 QUARTUS_RUNFILE_NAME="QuartusProProgrammerSetup-${DIB_QUARTUS_VERSION}-linux.run"
@@ -39,4 +41,3 @@ echo "/etc/profile.d/quartus.sh" >> /etc/rc.local
 
 # Ensure that /etc/rc.local is executable
 chmod +x /etc/rc.local
-

--- a/elements/fpga/extra-data.d/09-fpga-cache
+++ b/elements/fpga/extra-data.d/09-fpga-cache
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-  set -x
+    set -x
 fi
 set -eu
 set -o pipefail
 
 if [[ ! -d "${DIB_IMAGE_CACHE}/fpga" ]]; then
-  mkdir -p "${DIB_IMAGE_CACHE}/fpga"
+    mkdir -p "${DIB_IMAGE_CACHE}/fpga"
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,10 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+dev = [
+    "diskimage-builder>3.29.0"
+]
+
 [tool.setuptools]
 packages = ["cc_images"]


### PR DESCRIPTION
…estions

This PR looks a bit bigger than it actually is. Besides adding the dib-lint github job, the main changes revolve around fixing various issues found by dib-lint, specifically:

- creates temp README.rst files for each element to get the dib-lint job to pass since it has no built in way to ignore a missing README
- remove #!/bin/bash and execution mode from environment files since these are sourced, not executed
- use 4 spaces for bash tabs instead of 2
- alphabetize element dependencies
- add set e set u set pipefail dib debug trace bash to dib scripts (e.g. in install.d, pre-install.d, post-install.d, etc)
- set disable=sete setu setpipefail dibdebugtrace in non-dib scripts (like user scripts in bin that get installed into the image)
- makes any bin scripts executable

I did build the ubuntu 24 image to verify items touched by this still worked as expected.