### PR TITLE
Adds back node and lease motd using cached vendordata information

### DIFF
--- a/elements/cc-common/bin/cc-update-vendordata-cache
+++ b/elements/cc-common/bin/cc-update-vendordata-cache
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# dib-lint: disable=sete setu setpipefail dibdebugtrace
+
+URL="http://169.254.169.254/openstack/latest/vendor_data2.json"
+CACHE_FILE="/var/cache/vendordata2.json"
+
+for i in {1..10}; do
+    if json=$(curl -s --connect-timeout 5 "$URL"); then
+        node=$(echo "$json" | jq -r '.chameleon.node // empty')
+        region=$(echo "$json" | jq -r '.chameleon.region // empty')
+        lease_id=$(echo "$json" | jq -r '.chameleon.lease_id // empty')
+        lease_start=$(echo "$json" | jq -r '.chameleon.lease_start // empty')
+        lease_end=$(echo "$json" | jq -r '.chameleon.lease_end // empty')
+
+        {
+            echo "{"
+            echo "  \"chameleon\": {"
+            echo "    \"node\": \"$node\","
+            echo "    \"region\": \"$region\","
+            echo "    \"lease_id\": \"$lease_id\","
+            echo "    \"lease_start\": \"$lease_start\","
+            echo "    \"lease_end\": \"$lease_end\""
+            echo "  }"
+            echo "}"
+        } > "$CACHE_FILE"
+
+        chmod 0644 "$CACHE_FILE"
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "{}" > "$CACHE_FILE"
+chmod 0644 "$CACHE_FILE"

--- a/elements/cc-common/post-install.d/98-cache-vendordata
+++ b/elements/cc-common/post-install.d/98-cache-vendordata
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+ln -sf /etc/systemd/system/cache-vendordata.timer \
+    /etc/systemd/system/timers.target.wants/cache-vendordata.timer

--- a/elements/cc-common/static/etc/custom-motd/04-node-info
+++ b/elements/cc-common/static/etc/custom-motd/04-node-info
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# dib-lint: disable=sete setu setpipefail dibdebugtrace
+
+REGION=$(jq -r '.chameleon.region // empty' "/var/cache/vendordata2.json")
+if [ "${REGION}" = "KVM@TACC" ]; then
+    exit 0
+fi
+
+NODE_ID=$(jq -r '.chameleon.node // empty' "/var/cache/vendordata2.json")
+
+echo -e "\nNODE INFORMATION"
+
+if [ -z "$NODE_ID" ]; then
+    echo -e "\n    Node information is not available."
+    exit 0
+fi
+
+cat << EOF
+
+    Discover information about this node:
+
+    source ~/openrc
+    openstack reservation host show ${NODE_ID}
+EOF

--- a/elements/cc-common/static/etc/custom-motd/05-lease-info
+++ b/elements/cc-common/static/etc/custom-motd/05-lease-info
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# dib-lint: disable=sete setu setpipefail dibdebugtrace
+
+read_vendordata() {
+    local key="$1"
+    local default="${2:-}"
+    local vendordata_file="/var/cache/vendordata2.json"
+    if [ ! -f "$vendordata_file" ]; then
+        echo "$default"
+        return
+    fi
+    local value
+    value=$(jq -r --arg key "$key" '.chameleon[$key] // empty' "$vendordata_file")
+
+    if [ -n "$value" ]; then
+        echo "$value"
+    else
+        echo "$default"
+        return
+    fi
+}
+
+echo -e "\nLEASE INFORMATION"
+
+LEASE_ID=$(read_vendordata "lease_id")
+START_DATE=$(read_vendordata "lease_start")
+END_DATE=$(read_vendordata "lease_end")
+
+if [ -z "$LEASE_ID" ] || [ -z "$START_DATE" ] || [ -z "$END_DATE" ]; then
+    echo -e "\n    Lease information is not available."
+    exit 0
+fi
+
+END_SECONDS=$(date -d "${END_DATE%.*}" +%s)
+NOW_SECONDS=$(date +%s)
+DURATION=$((END_SECONDS - NOW_SECONDS))
+DURATION_DAYS=$((DURATION / 86400))
+DURATION_HOURS=$(( (DURATION % 86400) / 3600 ))
+
+cat << EOF
+
+    Lease ID: ${LEASE_ID}
+    Lease start: ${START_DATE}
+    Lease end: ${END_DATE}
+
+    Lease expires in ${DURATION_DAYS} days and ${DURATION_HOURS} hours
+EOF

--- a/elements/cc-common/static/etc/systemd/system/cache-vendordata.service
+++ b/elements/cc-common/static/etc/systemd/system/cache-vendordata.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Fetch and cache vendordata
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/cc-update-vendordata-cache

--- a/elements/cc-common/static/etc/systemd/system/cache-vendordata.timer
+++ b/elements/cc-common/static/etc/systemd/system/cache-vendordata.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run vendordata fetch every hour
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
I took some quick measurements sshing with and without MoTD on these new images:
```
===== Summary =====
Mode    Runs   Total(ms)   Avg(ms)
quiet    10       6480       648
motd     10       6825       682
```

For comparison on an image pre-these changes (`CC-Ubuntu24.04_2024-10-22`) with a generic Ubuntu MoTD:
```
===== Summary =====
Mode    Runs   Total(ms)   Avg(ms)
quiet    10       6107       610
motd     10       6510       651
```

I took the approach of caching what we need from vendordata, and updating it hourly (e.g. if a user extends their lease and re-logs in we want it to capture the new end date). Just doing lookups of vendordata adds about 2s per lookup. I didn't bother caching the MoTD files themselves since this got us well into the ballpark of reasonable imo that that felt like over-engineering.

Node information is completely skipped on KVM, but if you are on a KVM instance without a lease you'd currently see:
```
LEASE INFORMATION

    Lease information is not available.
```

I assumed that's fine as the plan is to eventually have them all on leases and this would start populating like bare metal nodes.

If you happen to login before the cache becomes available you'd see:
```
NODE INFORMATION

    Node information is not available.

LEASE INFORMATION

    Lease information is not available.
```