### PR TITLE
Return from sourced motd scripts, don't exit

### DIFF
--- a/elements/cc-common/static/etc/custom-motd/04-node-info
+++ b/elements/cc-common/static/etc/custom-motd/04-node-info
@@ -4,7 +4,11 @@
 
 REGION=$(jq -r '.chameleon.region // empty' "/var/cache/vendordata2.json")
 if [ "${REGION}" = "KVM@TACC" ]; then
-    exit 0
+    if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+        exit 0
+    else
+        return 0
+    fi
 fi
 
 NODE_ID=$(jq -r '.chameleon.node // empty' "/var/cache/vendordata2.json")
@@ -13,7 +17,11 @@ echo -e "\nNODE INFORMATION"
 
 if [ -z "$NODE_ID" ]; then
     echo -e "\n    Node information is not available."
-    exit 0
+    if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+        exit 0
+    else
+        return 0
+    fi
 fi
 
 cat << EOF

--- a/elements/cc-common/static/etc/custom-motd/05-lease-info
+++ b/elements/cc-common/static/etc/custom-motd/05-lease-info
@@ -29,7 +29,11 @@ END_DATE=$(read_vendordata "lease_end")
 
 if [ -z "$LEASE_ID" ] || [ -z "$START_DATE" ] || [ -z "$END_DATE" ]; then
     echo -e "\n    Lease information is not available."
-    exit 0
+    if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+        exit 0
+    else
+        return 0
+    fi
 fi
 
 END_SECONDS=$(date -d "${END_DATE%.*}" +%s)


### PR DESCRIPTION
Some distros execute (ubuntu) the motd and some source it (centos), so if we bail out we need to do so correctly. Just handling it in the scripts to avoid needing different copies for different distros.