### PR TITLE
Adds Ubuntu26.04 base image

### DIFF
--- a/config/images.yaml
+++ b/config/images.yaml
@@ -86,6 +86,15 @@ CC-Ubuntu24.04-CUDA-VGPU:
   provenance:
     variant: gpu
 
+CC-Ubuntu26.04:
+  arch:
+    - amd64
+    - arm64
+  provenance:
+    distro: ubuntu
+    release: resolute
+    variant: base
+
 CC-CentOS9-Stream:
   provenance:
     distro: centos

--- a/elements/cc-ubuntu26.04/element-deps
+++ b/elements/cc-ubuntu26.04/element-deps
@@ -1,0 +1,2 @@
+cc-common
+ubuntu

--- a/elements/cc-ubuntu26.04/environment.d/00-ubuntu-env
+++ b/elements/cc-ubuntu26.04/environment.d/00-ubuntu-env
@@ -1,0 +1,2 @@
+export DIB_RELEASE=resolute
+export DIB_DISTRO_VERSION=26.04


### PR DESCRIPTION
Note: I'm delaying adding cuda and rocm variants until nvidia and amd publish all their toolkits (not just drivers) in packages and repos for resolute so we can "just" install them like ubuntu24. Until then users can install and configure this base image as needed.